### PR TITLE
Use `AND` instead of `&&` which is unknown in SQLite

### DIFF
--- a/src/SM_GeoCoordsValueDescription.php
+++ b/src/SM_GeoCoordsValueDescription.php
@@ -68,7 +68,7 @@ class SMGeoCoordsValueDescription extends SMWValueDescription {
 			$conditions[] = "{$tableName}.$fieldNames[1] $comparator $lat";
 			$conditions[] = "{$tableName}.$fieldNames[2] $comparator $lon";
 
-			return implode( ' && ', $conditions );
+			return implode( ' AND ', $conditions );
 		}
 
 		return false;


### PR DESCRIPTION
Caused integration test to fail [0] with:

```
1) SMW\Tests\Integration\MediaWiki\SearchInPageDBIntegrationTest::testSearchForGeographicCoordinateValueAsTerm
RuntimeException: A database error has occurred. Did you forget to run maintenance/update.php after upgrading?  See: https://www.mediawiki.org/wiki/Manual:Upgrading#Run_the_update_script
Query: SELECT  DISTINCT t4.smw_id AS id,t4.smw_title AS t,t4.smw_namespace AS ns,t4.smw_iw AS iw,t4.smw_subobject AS so,t4.smw_sortkey AS sortkey  FROM sunittest_smw_object_ids AS t4 INNER JOIN sunittest_smw_di_coords AS t1 ON t4.smw_id=t1.s_id INNER JOIN sunittest_smw_object_ids AS t3 ON t1.s_id=t3.smw_id   WHERE ((t1.o_lat = '52.516666666667' && t1.o_lon = '13.4') AND t1.p_id='97' AND (t3.smw_namespace='0'))  ORDER BY t4.smw_sortkey ASC  LIMIT 15
Function: SMW::getQueryResult
Error: 1 near "&": syntax error

```

[0] https://s3.amazonaws.com/archive.travis-ci.org/jobs/44680860/log.txt
