### PR TITLE
change all attr('value') to .val()

### DIFF
--- a/src/forminputs/jquery.mapforminput.js
+++ b/src/forminputs/jquery.mapforminput.js
@@ -57,7 +57,7 @@
 	var updateButton = $( '<button />' ).text( mw.msg( 'semanticmaps-updatemap' ) );
 	
 	updateButton.click( function() {
-		var locations = coord.split( self.input.attr( 'value' ) );
+		var locations = coord.split( self.input.val() );
 		var location = coord.parse( locations[0] );
 		
 		if ( location !== false ) {
@@ -99,7 +99,7 @@
 	var geoButton = $( '<button />' ).text( mw.msg( 'semanticmaps_lookupcoordinates' ) );
 	
 	geoButton.click( function() {
-		self.geocodeAddress( self.geofield.attr( 'value' ) );
+		self.geocodeAddress( self.geofield.val() );
 		return false;
 	} );
 	


### PR DESCRIPTION
when we want to get the current value of a text input, we should use `.val()`. if we use `.attr('value')`, it only get the original value of the text input when the page was loaded.

eg.

when page is loaded:
<input name="city" value="helsinki"/>

then we typed new value:
<input name="city" value="beijing"/>

now let's get the value in 2 ways:

$('input[name="city"]').val() -> beijing
$('input[name="city"]').attr('value') -> helsinki