### PR TITLE
Update SM_MapPrinter.php

### DIFF
--- a/src/queryprinters/SM_MapPrinter.php
+++ b/src/queryprinters/SM_MapPrinter.php
@@ -191,7 +191,7 @@ class SMMapPrinter extends SMW\ResultPrinter {
 				Html::element(
 					'div',
 					array( 'style' => 'display:none', 'class' => 'mapdata' ),
-					FormatJson::encode( $this->getJSONObject( $params, $parser ) )
+					str_replace( '\\', '\\\\', FormatJson::encode( $this->getJSONObject( $params, $parser ) ) )
 				)
 		);
 	}


### PR DESCRIPTION
The MapPrinter rendered invalid JSON code, when the location's text contained quotes in the markup, like this:

    "locations":[{"text":"u003Cbu003Eu003Ca href="/Page_Title" title="Page Title"u003EPage Titleu003C/au003Eu003C/bu003E",

So the map did not render:

    SyntaxError: Unexpected token / SyntaxError: Unexpected token 

 I fixed it with this solution, now its output looks like this, so it renders fine

    "locations":[{"text":"\u003Cb\u003E\u003Ca href=\"/Page_Title\" title=\"Page Title\"\u003EPage Title\u003C/a\u003E\u003C/b\u003E",