### PR TITLE
Prevent error when parser output is null

### DIFF
--- a/src/queryprinters/SM_MapPrinter.php
+++ b/src/queryprinters/SM_MapPrinter.php
@@ -140,8 +140,7 @@ class SMMapPrinter extends SMW\ResultPrinter {
 		 */
 		global $wgParser;
 
-		global $egMapsEnableCategory;
-		if ($egMapsEnableCategory) {
+		if ( $GLOBALS['egMapsEnableCategory'] && $wgParser->getOutput() !== null ) {
 			$wgParser->addTrackingCategory( 'maps-tracking-category' );
 		}
 


### PR DESCRIPTION
No idea why it would be null... and presumably not something that should
be done outside of MW...

Fixes https://github.com/SemanticMediaWiki/SemanticMaps/issues/79