### PR TITLE
add ajax compoundquery support

### DIFF
--- a/src/ext.sm.common.js
+++ b/src/ext.sm.common.js
@@ -8,13 +8,13 @@
 window.sm = new ( function( $, mw ) {
 
     this.buildQueryString = function( query, ajaxcoordproperty, top, right, bottom, left ) {
-        var compoundQuery = query.indexOf('|') > -1;
+        var isCompoundQuery = query.indexOf('|') > -1;
         var query = query.split('|');
         $.each( query, function ( index ) {
             query[index] += ' [[' + ajaxcoordproperty + '::+]] ';
             query[index] += '[[' + ajaxcoordproperty + '::>' + bottom + '°, ' + left + '°]] ';
             query[index] += '[[' + ajaxcoordproperty + '::<' + top + '°, ' + right + '°]]';
-            if (!compoundQuery) {
+            if (!isCompoundQuery) {
                 query[index] += '|?' + ajaxcoordproperty;
             } else {
                 query[index] += ';?' + ajaxcoordproperty;
@@ -24,7 +24,8 @@ window.sm = new ( function( $, mw ) {
     };
 
     this.sendQuery = function( query ) {
-        var action = query.indexOf(';') > -1 ? 'compoundquery' : 'ask';
+        var isCompoundQuery = query.indexOf('|') > -1;
+        var action = isCompoundQuery ? 'compoundquery' : 'ask';
         return $.ajax( {
             method: 'GET',
             url: mw.util.wikiScript( 'api' ),

--- a/src/ext.sm.common.js
+++ b/src/ext.sm.common.js
@@ -8,19 +8,28 @@
 window.sm = new ( function( $, mw ) {
 
     this.buildQueryString = function( query, ajaxcoordproperty, top, right, bottom, left ) {
-        query += ' [[' + ajaxcoordproperty + '::+]] ';
-        query += '[[' + ajaxcoordproperty + '::>' + bottom + '°, ' + left + '°]] ';
-        query += '[[' + ajaxcoordproperty + '::<' + top + '°, ' + right + '°]]';
-        query += '|?' + ajaxcoordproperty;
-        return query;
+        var compoundQuery = query.indexOf('|') > -1;
+        var query = query.split('|');
+        $.each( query, function ( index ) {
+            query[index] += ' [[' + ajaxcoordproperty + '::+]] ';
+            query[index] += '[[' + ajaxcoordproperty + '::>' + bottom + '°, ' + left + '°]] ';
+            query[index] += '[[' + ajaxcoordproperty + '::<' + top + '°, ' + right + '°]]';
+            if (!compoundQuery) {
+                query[index] += '|?' + ajaxcoordproperty;
+            } else {
+                query[index] += ';?' + ajaxcoordproperty;
+            }
+        } );
+        return query.join(' | ');
     };
 
     this.sendQuery = function( query ) {
+        var action = query.indexOf(';') > -1 ? 'compoundquery' : 'ask';
         return $.ajax( {
             method: 'GET',
             url: mw.util.wikiScript( 'api' ),
             data: {
-                'action': 'ask',
+                'action': action,
                 'query': query,
                 'format': 'json'
             },


### PR DESCRIPTION
fix #74 

Example:

```
{{
#ask:
[[Category:Locations]] [[Has coordinates::47° 4' 0", 15° 26' 0" E  (50 km)]]
| ?Has coordinates
| format = googlemaps
| ajaxquery = [[Category:Wien]] {{!}} [[Category:Graz]]
| ajaxcoordproperty = Has coordinates
}}
```

`{{!}}` gets turned into `|` which makes it a compoundquery.