### PR TITLE
Allow null in getQueryDescription

### DIFF
--- a/src/SM_GeoCoordsValue.php
+++ b/src/SM_GeoCoordsValue.php
@@ -78,12 +78,12 @@ class SMGeoCoordsValue extends SMWDataValue {
 	 * 
 	 * @since 0.6
 	 * 
-	 * @param string $value
+	 * @param string|null $value
 	 * 
 	 * @return SMWDescription
 	 * @throws InvalidArgumentException
 	 */
-	public function getQueryDescription( $value ) {
+	public function getQueryDescription( $value = null ) {
 		if ( !is_string( $value ) ) {
 			throw new InvalidArgumentException( '$value needs to be a string' );
 		}


### PR DESCRIPTION
We allow null in `DataValue::getQueryDescription` with SMW 2.5 and to avoid a "Declaration of SMGeoCoordsValue::getQueryDescription() should be compatible with SMWDataValue::getQueryDescription($value = NULL)"